### PR TITLE
Abstract the schema metadata for use outside AMP

### DIFF
--- a/classes/class-wpcom-liveblog-amp.php
+++ b/classes/class-wpcom-liveblog-amp.php
@@ -132,7 +132,7 @@ class WPCOM_Liveblog_AMP {
 		}
 
 		$entry       = self::get_entry( $request->id, $post->ID );
-		$title       = self::get_entry_title( $entry );
+		$title       = WPCOM_Liveblog_Entry::get_entry_title( $entry );
 		$description = strip_tags( $entry->content );
 		$url         = self::build_single_entry_permalink( amp_get_permalink( $post->ID ), $entry->id );
 		$image       = self::get_entry_image( $entry );
@@ -363,16 +363,6 @@ class WPCOM_Liveblog_AMP {
 		$date_format = get_option( 'date_format' );
 
 		return date_i18n( $date_format, strtotime( $utc_offset, $entry->entry_time ) );
-	}
-
-	/**
-	 * Work out Entry title
-	 *
-	 * @param  object $entry Entry.
-	 * @return string        Title
-	 */
-	public static function get_entry_title( $entry ) {
-		return wp_trim_words( $entry->content, 10, '...' );
 	}
 
 	/**

--- a/classes/class-wpcom-liveblog-amp.php
+++ b/classes/class-wpcom-liveblog-amp.php
@@ -181,47 +181,13 @@ class WPCOM_Liveblog_AMP {
 	 */
 	public static function append_liveblog_to_metadata( $metadata, $post ) {
 
-		// If we are not viewing a liveblog post then exist the filter.
-		if ( WPCOM_Liveblog::is_liveblog_post( $post->ID ) === false ) {
-			return $metadata;
+		// Only append metadata to Liveblogs.
+		if ( false !== WPCOM_Liveblog::is_liveblog_post( $post->ID ) ) {
+			/**
+			 * This filter is documented in liveblog.php
+			 */
+			$metadata = WPCOM_Liveblog::get_liveblog_metadata();
 		}
-
-		$request = self::get_request_data();
-
-		$entries = WPCOM_Liveblog::get_entries_paged( $request->page, $request->last );
-
-		$blog_updates = [];
-
-		if ( ! isset( $entries[ 'entries' ] ) || ! is_array( $entries[ 'entries' ] ) ) {
-			return $metadata;
-		}
-
-		foreach ( $entries[ 'entries' ] as $key => $entry ) {
-			$blog_item = [
-				'@type'            => 'BlogPosting',
-				'headline'         => self::get_entry_title( $entry ),
-				'url'              => $entry->share_link,
-				'mainEntityOfPage' => $entry->share_link,
-				'datePublished'    => date( 'c', $entry->entry_time ),
-				'dateModified'     => date( 'c', $entry->timestamp ),
-				'author'           => [
-					'@type' => 'Person',
-					'name'  => $entry->authors[ 0 ][ 'name' ],
-				],
-				'articleBody'      => [
-					'@type' => 'Text',
-				],
-			];
-
-			if ( isset( $metadata['publisher'] ) ) {
-				$blog_item['publisher'] = $metadata['publisher'];
-			}
-
-			$blog_updates[] = json_decode( json_encode( $blog_item ) );
-		}
-
-		$metadata['@type']          = 'LiveBlogPosting';
-		$metadata['liveBlogUpdate'] = $blog_updates;
 
 		return $metadata;
 	}

--- a/classes/class-wpcom-liveblog-amp.php
+++ b/classes/class-wpcom-liveblog-amp.php
@@ -124,7 +124,7 @@ class WPCOM_Liveblog_AMP {
 			return;
 		}
 
-		$request = self::get_request_data();
+		$request = WPCOM_Liveblog::get_request_data();
 
 		// If no entry id set then not on single entry.
 		if ( false === $request->id ) {
@@ -205,7 +205,7 @@ class WPCOM_Liveblog_AMP {
 			return $content;
 		}
 
-		$request = self::get_request_data();
+		$request = WPCOM_Liveblog::get_request_data();
 
 		if ( $request->id ) {
 			$entries  = WPCOM_Liveblog::get_entries_paged( false, false, $request->id );
@@ -433,19 +433,6 @@ class WPCOM_Liveblog_AMP {
 			array(
 				'liveblog_id' => $id,
 			), $permalink
-		);
-	}
-
-	/**
-	 * Get Page and Last known entry from the request.
-	 *
-	 * @return object Request Data.
-	 */
-	public static function get_request_data() {
-		return (object) array(
-			'page' => get_query_var( 'liveblog_page', 1 ),
-			'last' => get_query_var( 'liveblog_last', false ),
-			'id'   => get_query_var( 'liveblog_id', false ),
 		);
 	}
 

--- a/classes/class-wpcom-liveblog-entry.php
+++ b/classes/class-wpcom-liveblog-entry.php
@@ -492,6 +492,17 @@ class WPCOM_Liveblog_Entry {
 
 		return array_merge( $author, $contributors );
 	}
+
+	/**
+	 * Work out Entry title
+	 *
+	 * @param  object $entry Entry.
+	 * @return string        Title
+	 */
+	public static function get_entry_title( $entry ) {
+		return wp_trim_words( $entry->content, 10, '...' );
+	}
+
 }
 
 WPCOM_Liveblog_Entry::generate_allowed_tags_for_entry();

--- a/liveblog.php
+++ b/liveblog.php
@@ -1781,6 +1781,8 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 		 */
 		public static function get_liveblog_metadata() {
 
+			global $post;
+
 			// If we are not viewing a liveblog post then exist the filter.
 			if ( WPCOM_Liveblog::is_liveblog_post( $post->ID ) === false ) {
 				return $metadata;
@@ -1828,14 +1830,16 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 			return $metadata;
 		}
 
-		public function print_liveblog_metadata() {
+		public static function print_liveblog_metadata() {
+
+			global $post;
 
 			// Bail if we are not viewing a liveblog.
 			if ( WPCOM_Liveblog::is_liveblog_post( $post->ID ) === false ) {
 				return;
 			}
 
-			$metadata = self::get_liveblog_metadata();
+			$metadata = WPCOM_Liveblog::get_liveblog_metadata();
 			if ( empty( $metadata ) ) {
 				return;
 			}
@@ -1844,6 +1848,19 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 			<script type="application/ld+json"><?php echo wp_json_encode( $metadata ); ?></script>
 			<?php
 
+		}
+
+		/**
+		 * Get Page and Last known entry from the request.
+		 *
+		 * @return object Request Data.
+		 */
+		public static function get_request_data() {
+			return (object) array(
+				'page' => get_query_var( 'liveblog_page', 1 ),
+				'last' => get_query_var( 'liveblog_last', false ),
+				'id'   => get_query_var( 'liveblog_id', false ),
+			);
 		}
 
 	}

--- a/liveblog.php
+++ b/liveblog.php
@@ -1842,10 +1842,8 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 
 		public static function print_liveblog_metadata() {
 
-			global $post;
-
 			// Bail if we are not viewing a liveblog.
-			if ( WPCOM_Liveblog::is_liveblog_post( $post->ID ) === false ) {
+			if ( WPCOM_Liveblog::is_liveblog_post( get_the_ID() ) === false ) {
 				return;
 			}
 

--- a/liveblog.php
+++ b/liveblog.php
@@ -1783,7 +1783,7 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 
 			global $post;
 
-			// If we are not viewing a liveblog post then exist the filter.
+			// If we are not viewing a liveblog post then exit the filter.
 			if ( WPCOM_Liveblog::is_liveblog_post( $post->ID ) === false ) {
 				return $metadata;
 			}
@@ -1826,7 +1826,7 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 			$metadata['liveBlogUpdate'] = $blog_updates;
 
 			/**
-			 * Filters lhe Liveblog metadata.
+			 * Filters the Liveblog metadata.
 			 *
 			 * Allows plugins and themes to adapt the metadata printed by the
 			 * liveblog into the head, describing the liveblog and it's entries.

--- a/liveblog.php
+++ b/liveblog.php
@@ -173,6 +173,7 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 			add_action( 'admin_enqueue_scripts', array( __CLASS__, 'admin_enqueue_scripts' ) );
 			add_action( 'wp_ajax_set_liveblog_state_for_post', array( __CLASS__, 'admin_ajax_set_liveblog_state_for_post' ) );
 			add_action( 'pre_get_posts', array( __CLASS__, 'add_custom_post_type_support' ) );
+			add_action( 'wp_head', array( __CLASS__, 'print_liveblog_metadata' ) );
 		}
 
 		/**
@@ -1769,6 +1770,80 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 			$refresh_interval = apply_filters( 'liveblog_refresh_interval', $refresh_interval );
 			$refresh_interval = apply_filters( 'liveblog_post_' . self::$post_id . '_refresh_interval', $refresh_interval );
 			return $refresh_interval;
+		}
+
+		/**
+		 * Generates metadata for a single liveblog
+		 *
+		 * @param  array   $metadata Metadata.
+		 * @param  WP_Post $post     Current Post.
+		 * @return array             Updated Meta
+		 */
+		public static function get_liveblog_metadata() {
+
+			// If we are not viewing a liveblog post then exist the filter.
+			if ( WPCOM_Liveblog::is_liveblog_post( $post->ID ) === false ) {
+				return $metadata;
+			}
+
+			$request = self::get_request_data();
+
+			$entries = WPCOM_Liveblog::get_entries_paged( $request->page, $request->last );
+
+			$blog_updates = [];
+
+			if ( ! isset( $entries[ 'entries' ] ) || ! is_array( $entries[ 'entries' ] ) ) {
+				return $metadata;
+			}
+
+			foreach ( $entries[ 'entries' ] as $key => $entry ) {
+				$blog_item = [
+					'@type'            => 'BlogPosting',
+					'headline'         => self::get_entry_title( $entry ),
+					'url'              => $entry->share_link,
+					'mainEntityOfPage' => $entry->share_link,
+					'datePublished'    => date( 'c', $entry->entry_time ),
+					'dateModified'     => date( 'c', $entry->timestamp ),
+					'author'           => [
+						'@type' => 'Person',
+						'name'  => $entry->authors[ 0 ][ 'name' ],
+					],
+					'articleBody'      => [
+						'@type' => 'Text',
+					],
+				];
+
+				if ( isset( $metadata['publisher'] ) ) {
+					$blog_item['publisher'] = $metadata['publisher'];
+				}
+
+				$blog_updates[] = json_decode( json_encode( $blog_item ) );
+			}
+
+			$metadata['@type']          = 'LiveBlogPosting';
+			$metadata['liveBlogUpdate'] = $blog_updates;
+
+			apply_filters( 'liveblog_metadata', $metadata, $post );
+
+			return $metadata;
+		}
+
+		public function print_liveblog_metadata() {
+
+			// Bail if we are not viewing a liveblog.
+			if ( WPCOM_Liveblog::is_liveblog_post( $post->ID ) === false ) {
+				return;
+			}
+
+			$metadata = self::get_liveblog_metadata();
+			if ( empty( $metadata ) ) {
+				return;
+			}
+
+			?>
+			<script type="application/ld+json"><?php echo wp_json_encode( $metadata ); ?></script>
+			<?php
+
 		}
 
 	}

--- a/liveblog.php
+++ b/liveblog.php
@@ -1801,7 +1801,7 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 			foreach ( $entries[ 'entries' ] as $key => $entry ) {
 				$blog_item = [
 					'@type'            => 'BlogPosting',
-					'headline'         => self::get_entry_title( $entry ),
+					'headline'         => WPCOM_Liveblog_Entry::get_entry_title( $entry ),
 					'url'              => $entry->share_link,
 					'mainEntityOfPage' => $entry->share_link,
 					'datePublished'    => date( 'c', $entry->entry_time ),

--- a/liveblog.php
+++ b/liveblog.php
@@ -1825,7 +1825,17 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 			$metadata['@type']          = 'LiveBlogPosting';
 			$metadata['liveBlogUpdate'] = $blog_updates;
 
-			apply_filters( 'liveblog_metadata', $metadata, $post );
+			/**
+			 * Filters lhe Liveblog metadata.
+			 *
+			 * Allows plugins and themes to adapt the metadata printed by the
+			 * liveblog into the head, describing the liveblog and it's entries.
+			 *
+			 * @since 1.9
+			 *
+			 * @param array $metadata An array of metadata.
+			 */
+			$metadata = apply_filters( 'liveblog_metadata', $metadata, $post );
 
 			return $metadata;
 		}


### PR DESCRIPTION
This change moves the metadata generation outside the AMP class and adds it into the non-AMP versions of liveblogs, as well as the AMP version.

We also introduce a new filter, `liveblog_metadata` so that the metadata can be tweaked by plugins and/or themes.